### PR TITLE
Revert "Replace deprecated `set-output` with `GITHUB_OUTPUT` method"

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -41,8 +41,7 @@ except subprocess.CalledProcessError as e:
 version = version.decode("utf-8")
 print(version)
 version = version.split(" ")[1]
-with open(os.environ["GITHUB_OUTPUT"], "a") as github_output:
-    print(f"esphome-version={version}", file=github_output)
+print(f"::set-output name=esphome-version::{version}")
 print("::endgroup::")
 
 print("::group::Get config")
@@ -67,8 +66,7 @@ elif "esp8266" in config:
 
 name += f"-{platform}"
 
-with open(os.environ["GITHUB_OUTPUT"], "a") as github_output:
-    print(f"name={name}", file=github_output)
+print(f"::set-output name=name::{name}")
 print("::endgroup::")
 
 file_base = Path(name)


### PR DESCRIPTION
Reverts esphome/build-action#12