### PR TITLE
Add Multi-Arch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ This action is used by the [ESPHome publish workflow](https://github.com/esphome
 
 ## Inputs
 
-Name | Default | Description  
------|---------|------------
-`yaml_file` | _None_   | The YAML file to be compiled.
-`version`   | `latest` | The ESPHome version to build using.
+Name        | Default       | Description  
+------------|---------------|------------
+`yaml_file` | _None_        | The YAML file to be compiled.
+`version`   | `latest`      | The ESPHome version to build using.
+`platform`  | `linux/amd64` | The docker platform to use during build. (linux/amd64, linux/arm64, linux/arm/v7)
 
 ## Outputs
 
-Name   | Description  
--------|------------
-`name` | The name of the device in yaml with the platform (eg. ESP32 or ESP8266) appended.
+Name      | Description  
+----------|------------
+`name`    | The name of the device in yaml with the platform (eg. ESP32 or ESP8266) appended.
+`version` | The ESPHome version used during build.
 
 ## Output files
 

--- a/action.yml
+++ b/action.yml
@@ -5,12 +5,14 @@ inputs:
   yaml_file:
     description: YAML file to use
     required: true
-    type: string
   version:
     description: Version of ESPHome to build
     required: false
-    type: string
     default: latest
+  platform:
+    description: Platform (OS/Arch) to use
+    required: false
+    default: linux/amd64
 
 outputs:
   name:
@@ -23,18 +25,25 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        platforms: ${{ inputs.platform }}
     - name: Build ESPHome image
-      shell: bash
-      run: |-
-        docker build \
-        -t esphome:${{ inputs.version }} \
-        --build-arg VERSION=${{ inputs.version }} \
-        ${{ github.action_path }}
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ github.action_path }}
+        load: true
+        tags: esphome:${{ inputs.version }}
+        build-args: VERSION=${{ inputs.version }}
+        platforms: ${{ inputs.platform }}
     - name: Run container
       shell: bash
       id: build-step
       run: |-
-        docker run --rm \
+        docker run --rm --platform ${{ inputs.platform }} \
         --workdir /github/workspace -v "$(pwd)":"/github/workspace" \
         -e INPUT_YAML_FILE -e HOME -e GITHUB_JOB -e GITHUB_REF \
         -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER \


### PR DESCRIPTION
Utilize docker-qemu to build/test against any platform supported by ESPHome.

[Example workflow config using this action](https://github.com/vidplace7/esphome-wemos/blob/main/.github/workflows/ci-multiarch.yml):
```yaml
jobs:
  ci-multiarch:
    name: Build ${{ matrix.file }} - ${{ matrix.platform }} - ESPHome ${{ matrix.version }}
    runs-on: ubuntu-latest
    continue-on-error: ${{ matrix.accept_failure || false }}
    strategy:
      fail-fast: false
      matrix:
        file:
          - esp32-wemos-c3-mini.yaml
          - esp32-wemos-s2-mini.yaml
          - esp8266-wemos-d1-mini.yaml
        version:
          - latest
        platform:
          - linux/amd64
          - linux/arm64
          - linux/arm/v7
        include:
          - platform: linux/arm/v7
            accept_failure: true
    steps:
      - name: Checkout source code
        uses: actions/checkout@v3
      - name: Build ESPHome firmware to verify configuration
        uses: vidplace7/esphome-build-action@feature-multiarch
        with:
          yaml_file: ${{ matrix.file }}
          version: ${{ matrix.version }}
          platform: ${{ matrix.platform }}
```
Example run using this configuration:
https://github.com/vidplace7/esphome-wemos/actions/runs/3726832437/jobs/6320535854