### PR TITLE
Use ESP32 variant as the platform

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -61,7 +61,7 @@ name = config["esphome"]["name"]
 
 platform = ""
 if "esp32" in config:
-    platform = "esp32"
+    platform = config["esp32"]["variant"].lower()
 elif "esp8266" in config:
     platform = "esp8266"
 elif "rp2040" in config:


### PR DESCRIPTION
Examples:
- `esp32`
- `esp32c3`
- `esp32s2`
- `esp32s3`
- `esp32h2`
- `esp32c6`