### PR TITLE
chore: Adding dependabot and manually updating actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/action.yml
+++ b/action.yml
@@ -26,13 +26,13 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         platforms: ${{ inputs.platform }}
     - name: Build ESPHome image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v5
       with:
         context: ${{ github.action_path }}
         load: true

--- a/action.yml
+++ b/action.yml
@@ -26,13 +26,13 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v3.0.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v3.0.0
       with:
         platforms: ${{ inputs.platform }}
     - name: Build ESPHome image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v5.1.0
       with:
         context: ${{ github.action_path }}
         load: true


### PR DESCRIPTION
This adds automated dependency checking via dependabot and manually upgrades dependencies to get rid of warnings and fix #21

Tested here: https://github.com/barndawgie/esphome-econet/actions/runs/7699224556?pr=60