### PR TITLE
Copy ota binaries and build ota section of manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 venv
 *.bin
 *.json
+config/

--- a/README.md
+++ b/README.md
@@ -2,39 +2,43 @@
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/esphome/build-action)
 
-
 This action takes a yaml file for an ESPHome device and will compile and output
-the build firmware file and a partial `manifest.json` file that can be used to flash 
+the build firmware file and a partial `manifest.json` file that can be used to flash
 a device via [ESP Web Tools](https://esphome.github.io/esp-web-tools).
 
 ## Example usage
 
 ```yaml
-
 uses: esphome/build-action@v1
 with:
   yaml_file: my_configuration.yaml
-
 ```
 
 This action is used by the [ESPHome publish workflow](https://github.com/esphome/workflows/blob/main/.github/workflows/publish.yml) that is used to compile firmware and publish simple GitHub pages sites for projects.
 
 ## Inputs
 
-Name        | Default       | Description  
-------------|---------------|------------
-`yaml_file` | _None_        | The YAML file to be compiled.
-`version`   | `latest`      | The ESPHome version to build using.
-`platform`  | `linux/amd64` | The docker platform to use during build. (linux/amd64, linux/arm64, linux/arm/v7)
-`cache`     | `false`       | Whether to cache the build folder.
+| Name              | Default       | Description                                                                       |
+| ----------------- | ------------- | --------------------------------------------------------------------------------- |
+| `yaml_file`       | _None_        | The YAML file to be compiled.                                                     |
+| `version`         | `latest`      | The ESPHome version to build using.                                               |
+| `platform`        | `linux/amd64` | The docker platform to use during build. (linux/amd64, linux/arm64, linux/arm/v7) |
+| `cache`           | `false`       | Whether to cache the build folder.                                                |
+| `release_summary` | _None_        | A small summary of the release that will be added to the manifest file.           |
+| `release_url`     | _None_        | A URL to the release page that will be added to the manifest file.                |
 
 ## Outputs
 
-Name      | Description  
-----------|------------
-`name`    | The name of the device in yaml with the platform (eg. ESP32 or ESP8266) appended.
-`version` | The ESPHome version used during build.
+| Name            | Description                                                                       |
+| --------------- | --------------------------------------------------------------------------------- |
+| `name`          | The name of the device in yaml with the platform (eg. ESP32 or ESP8266) appended. |
+| `version`       | The ESPHome version used during build.                                            |
+| `original_name` | The original name of the device in yaml.                                          |
 
 ## Output files
 
-This action will output a folder named with the output `name` and will contain two files, `{name}.bin` and `manifest.json`.
+This action will output a folder named with the output `name` and will contain three files:
+
+- `manifest.json` - This goes into the `builds` section of an esp-web-tools manifest.json.
+- `{name}.factory.bin` - The firmware to be flashed with esp-web-tools.
+- `{name}.ota.bin` - The firmware that can be flashed over-the-air to the device using the [Managed Updated via HTTP Request](https://esphome.io/components/update/http_request).

--- a/action.yml
+++ b/action.yml
@@ -17,14 +17,25 @@ inputs:
     description: Cache build directory
     required: false
     default: false
+  release_summary:
+    description: Release summary
+    required: false
+    default: ""
+  release_url:
+    description: Release URL
+    required: false
+    default: ""
 
 outputs:
   name:
-    description: Name of device extracted from configuration
+    description: Name of device extracted from configuration with the platform appended
     value: ${{ steps.build-step.outputs.name }}
   version:
     description: ESPHome version
     value: ${{ steps.build-step.outputs.esphome-version }}
+  original_name:
+    description: Original name of device extracted from configuration
+    value: ${{ steps.build-step.outputs.original_name }}
 
 runs:
   using: composite
@@ -79,6 +90,7 @@ runs:
         -v "$(pwd)":"/github/workspace" -v "$HOME:$HOME" \
         --user $(id -u):$(id -g) \
         -e INPUT_YAML_FILE -e HOME \
+        -e INPUT_RELEASE_SUMMARY -e INPUT_RELEASE_URL \
         -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY \
         -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER \
         -e GITHUB_ACTOR -e GITHUB_OUTPUT \


### PR DESCRIPTION
This updates the action to also produce the ota binary and `ota` section of the manifest for ota flashing.

```json
{
  "chipFamily": "ESP32",
  "ota": {
    "path": "test-esp32/test-esp32.ota.bin",
    "md5": "a2c4bdfabdfe1cbf459a9ef5e48b767a"
  },
  "parts": [
    {
      "path": "test-esp32/test-esp32.factory.bin",
      "offset": 0
    }
  ]
}
```

This is a breaking change because the binary for flashing is now named `firmware.factory.bin` instead of `firmware.bin`.

In most cases if using this action and the manifest as is, then it should be fine as the manifest contains the path correctly.