### PR TITLE
Output project name and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ This action is used by the [ESPHome publish workflow](https://github.com/esphome
 
 ## Outputs
 
-| Name            | Description                                                                       |
-| --------------- | --------------------------------------------------------------------------------- |
-| `name`          | The name of the device in yaml with the platform (eg. ESP32 or ESP8266) appended. |
-| `version`       | The ESPHome version used during build.                                            |
-| `original_name` | The original name of the device in yaml.                                          |
+| Name              | Description                                                                       |
+| ----------------- | --------------------------------------------------------------------------------- |
+| `name`            | The name of the device in yaml with the platform (eg. ESP32 or ESP8266) appended. |
+| `version`         | The ESPHome version used during build.                                            |
+| `original-name`   | The original name of the device in yaml.                                          |
+| `project-name`    | The name of the project in yaml. `esphome.project.name`                           |
+| `project-version` | The version of the project in yaml. `esphome.project.version`                     |
 
 ## Output files
 

--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,17 @@ outputs:
     description: ESPHome version
     value: ${{ steps.build-step.outputs.esphome-version }}
   original_name:
+    description: "Original name of device extracted from configuration (DEPRECATED: Use `original-name` instead)"
+    value: ${{ steps.build-step.outputs.original-name }}
+  original-name:
     description: Original name of device extracted from configuration
-    value: ${{ steps.build-step.outputs.original_name }}
+    value: ${{ steps.build-step.outputs.original-name }}
+  project-name:
+    description: Project name extracted from configuration
+    value: ${{ steps.build-step.outputs.project-name }}
+  project-version:
+    description: Project version extracted from configuration
+    value: ${{ steps.build-step.outputs.project-version }}
 
 runs:
   using: composite

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -118,7 +118,6 @@ def get_config(filename: Path, outputs_file: str | None) -> tuple[Config | None,
 
     if outputs_file:
         with open(outputs_file, "a", encoding="utf-8") as output:
-            print(f"original_name={original_name}", file=output)
             print(f"original-name={original_name}", file=output)
 
     platform = ""

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -75,6 +75,8 @@ class Config:
     platform: str
     original_name: str
 
+    raw_config: dict | None = None
+
     def dest_factory_bin(self, file_base: Path) -> Path:
         """Get the destination factory binary path."""
         if self.platform == "rp2040":
@@ -117,6 +119,7 @@ def get_config(filename: Path, outputs_file: str | None) -> tuple[Config | None,
     if outputs_file:
         with open(outputs_file, "a", encoding="utf-8") as output:
             print(f"original_name={original_name}", file=output)
+            print(f"original-name={original_name}", file=output)
 
     platform = ""
     if "esp32" in config:
@@ -131,8 +134,16 @@ def get_config(filename: Path, outputs_file: str | None) -> tuple[Config | None,
     if outputs_file:
         with open(outputs_file, "a", encoding="utf-8") as output:
             print(f"name={name}", file=output)
+
+    if project_config := config["esphome"].get("project"):
+        if outputs_file:
+            with open(outputs_file, "a", encoding="utf-8") as output:
+                print(f"project-name={project_config['name']}", file=output)
+                print(f"project-version={project_config['version']}", file=output)
     print("::endgroup::")
-    return Config(name=name, platform=platform, original_name=original_name), 0
+    return Config(
+        name=name, platform=platform, original_name=original_name, raw_config=config
+    ), 0
 
 
 def get_idedata(filename: Path) -> tuple[dict | None, int]:

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -1,5 +1,8 @@
 esphome:
   name: test
+  project:
+    name: esphome.example-project
+    version: "3.5.0"
 
 esp32:
   board: esp32dev


### PR DESCRIPTION
This adds new outputs: 
- project-name
- project-version

It also deprecates and replaces `original_name` (underscored) with `original-name` (hypened)
`original_name` will be removed in the next major release.