### PR TITLE
Write path relative to manifest.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
         uses: ./
         id: esphome-build
         with:
-          yaml_file: tests/test.yaml
+          yaml-file: tests/test.yaml
           version: ${{ matrix.esphome-version }}
           platform: linux/amd64
           cache: true
-          release_summary: "Test release summary"
-          release_url: "https://github.com/esphome/build-action"
+          release-summary: "Test release summary"
+          release-url: "https://github.com/esphome/build-action"
           complete-manifest: ${{ matrix.manifest == 'complete' }}
       - name: Write version to file
         run: echo ${{ steps.esphome-build.outputs.version }} > ${{ steps.esphome-build.outputs.name }}/version

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: ESPHome Builder
 description: Builds ESPHome binaries
 
 inputs:
-  yaml_file:
+  yaml-file:
     description: YAML file to use
     required: true
   version:
@@ -17,11 +17,11 @@ inputs:
     description: Cache build directory
     required: false
     default: false
-  release_summary:
+  release-summary:
     description: Release summary
     required: false
     default: ""
-  release_url:
+  release-url:
     description: Release URL
     required: false
     default: ""
@@ -37,9 +37,6 @@ outputs:
   version:
     description: ESPHome version
     value: ${{ steps.build-step.outputs.esphome-version }}
-  original_name:
-    description: "Original name of device extracted from configuration (DEPRECATED: Use `original-name` instead)"
-    value: ${{ steps.build-step.outputs.original-name }}
   original-name:
     description: Original name of device extracted from configuration
     value: ${{ steps.build-step.outputs.original-name }}
@@ -71,27 +68,27 @@ runs:
       id: data-dir
       shell: bash
       run: |
-        data_dir=$(dirname ${{ inputs.yaml_file }})/.esphome
+        data_dir=$(dirname ${{ inputs.yaml-file }})/.esphome
         echo "data_dir=$data_dir" >> $GITHUB_OUTPUT
     - if: ${{ inputs.cache == 'true' }}
       name: Cache platformio directory
       uses: actions/cache@v4.0.2
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-esphome-${{ inputs.yaml_file }}-${{ inputs.version }}-platformio
+        key: ${{ runner.os }}-esphome-${{ inputs.yaml-file }}-${{ inputs.version }}-platformio
     - if: ${{ inputs.cache == 'true' }}
       name: Cache build directory
       uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.data-dir.outputs.data_dir }}/build
-        key: ${{ runner.os }}-esphome-${{ inputs.yaml_file }}-${{ inputs.version }}-build
+        key: ${{ runner.os }}-esphome-${{ inputs.yaml-file }}-${{ inputs.version }}-build
         save-always: true
     - if: ${{ inputs.cache == 'true' }}
       name: Cache storage directory
       uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.data-dir.outputs.data_dir }}/storage
-        key: ${{ runner.os }}-esphome-${{ inputs.yaml_file }}-${{ inputs.version }}-storage
+        key: ${{ runner.os }}-esphome-${{ inputs.yaml-file }}-${{ inputs.version }}-storage
         save-always: true
     - name: Run container
       shell: bash
@@ -104,9 +101,9 @@ runs:
           --user $(id -u):$(id -g) \
           -e HOME \
           esphome:${{ inputs.version }} \
-            ${{ inputs.yaml_file }} \
-            --release-summary "${{ inputs.release_summary }}" \
-            --release-url "${{ inputs.release_url }}" \
+            ${{ inputs.yaml-file }} \
+            --release-summary "${{ inputs.release-summary }}" \
+            --release-url "${{ inputs.release-url }}" \
             --outputs-file "$GITHUB_OUTPUT" \
             ${{ inputs.complete-manifest == 'true' && '--complete-manifest' || '--partial-manifest' }}
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -227,7 +227,7 @@ def generate_manifest_part(
     manifest = {
         "chipFamily": chip_family,
         "ota": {
-            "path": str(ota_bin),
+            "path": ota_bin.name,
             "md5": ota_md5,
         },
     }
@@ -240,7 +240,7 @@ def generate_manifest_part(
     if has_factory_part:
         manifest["parts"] = [
             {
-                "path": str(factory_bin),
+                "path": str(factory_bin.name),
                 "offset": 0x00,
             }
         ]

--- a/tests/complete-manifest-template.json
+++ b/tests/complete-manifest-template.json
@@ -7,14 +7,14 @@
     {
       "chipFamily": "ESP32",
       "ota": {
-        "path": "test-esp32/test-esp32.ota.bin",
+        "path": "test-esp32.ota.bin",
         "md5": "\($md5)",
         "summary": "Test release summary",
         "release_url": "https://github.com/esphome/build-action"
       },
       "parts": [
         {
-          "path": "test-esp32/test-esp32.factory.bin",
+          "path": "test-esp32.factory.bin",
           "offset": 0
         }
       ]

--- a/tests/partial-manifest-template.json
+++ b/tests/partial-manifest-template.json
@@ -1,14 +1,14 @@
 {
   "chipFamily": "ESP32",
   "ota": {
-    "path": "test-esp32/test-esp32.ota.bin",
+    "path": "test-esp32.ota.bin",
     "md5": "\($md5)",
     "summary": "Test release summary",
     "release_url": "https://github.com/esphome/build-action"
   },
   "parts": [
     {
-      "path": "test-esp32/test-esp32.factory.bin",
+      "path": "test-esp32.factory.bin",
       "offset": 0
     }
   ]


### PR DESCRIPTION
## Breaking Changes

- Writes `manifest.json` `path`s with no directory prefixed
- Replaces inputs to use `-` separator for consistency
  - `yaml_file` => `yaml-file` 
  - `release_summary` => `release-summary`
  - `release_url` => `release-url`
- Removes deprecated output `original_name`. Use `original-name` instead.

To upgrade to this version you will need to: 
- alter your workflows to use the new input names and output name
- add a new step to rewrite the manifest paths if you host the `manifest.json` file in a directory that the `.bin` files are not located in.