### PR TITLE
Disable docker build artifacts and summaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,9 @@ runs:
         platforms: ${{ inputs.platform }}
     - name: Build ESPHome image
       uses: docker/build-push-action@v6.5.0
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
       with:
         context: ${{ github.action_path }}
         load: true


### PR DESCRIPTION
These summaries and artifacts are not needed for this action as we are only building a local image to be used for building firmware.