### PR TITLE
Use project name before friendly name and hostname

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -313,7 +313,7 @@ def main(argv) -> int:
 
     if args.complete_manifest:
         manifest = {
-            "name": config.friendly_name or config.original_name,
+            "name": config.project_name or config.friendly_name or config.original_name,
             "version": config.project_version or esphome_version,
             "home_assistant_domain": "esphome",
             "new_install_prompt_erase": False,

--- a/tests/complete-manifest-template.json
+++ b/tests/complete-manifest-template.json
@@ -1,5 +1,5 @@
 {
-  "name": "test",
+  "name": "example-project",
   "version": "3.5.0",
   "home_assistant_domain": "esphome",
   "new_install_prompt_erase": false,

--- a/tests/complete-manifest-template.json
+++ b/tests/complete-manifest-template.json
@@ -1,5 +1,5 @@
 {
-  "name": "example-project",
+  "name": "esphome.example-project",
   "version": "3.5.0",
   "home_assistant_domain": "esphome",
   "new_install_prompt_erase": false,


### PR DESCRIPTION
This will prioritise using the project name as the name in the manifest over the friendly name and hostname.