### PR TITLE
Remove platform input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build:
-    name: Build test configuration for esphome:${{ matrix.esphome-version }} with ${{ matrix.manifest }} manifest on ${{ matrix.os }}
+    name: esphome:${{ matrix.esphome-version }} / ${{ matrix.manifest }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Upload ESPHome binary
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: build-output-files-${{ matrix.esphome-version }}-${{ matrix.manifest }}
+          name: build-output-files-${{ matrix.esphome-version }}-${{ matrix.manifest }}-${{ matrix.os }}
           path: ${{ steps.esphome-build.outputs.name }}
 
   verify:
     name: Verify output files for esphome:${{ matrix.esphome-version }} with ${{ matrix.manifest }} manifest
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build
     strategy:
       fail-fast: false
@@ -74,13 +74,17 @@ jobs:
         manifest:
           - complete
           - partial
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Download files
         uses: actions/download-artifact@v4.2.1
         with:
-          name: build-output-files-${{ matrix.esphome-version }}-${{ matrix.manifest }}
+          name: build-output-files-${{ matrix.esphome-version }}-${{ matrix.manifest }}-${{ matrix.os }}
 
       - name: List files
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       max-parallel: 2
       matrix:
         esphome-version:
-          # - stable
-          # - beta
+          - stable
+          - beta
           - dev
         manifest:
           - complete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       max-parallel: 2
       matrix:
         esphome-version:
-          - stable
-          - beta
+          # - stable
+          # - beta
           - dev
         manifest:
           - complete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ env:
 
 jobs:
   build:
-    name: Build test configuration for esphome:${{ matrix.esphome-version }} with ${{ matrix.manifest }} manifest
-    runs-on: ubuntu-latest
+    name: Build test configuration for esphome:${{ matrix.esphome-version }} with ${{ matrix.manifest }} manifest on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         esphome-version:
           - stable
@@ -36,6 +37,9 @@ jobs:
         manifest:
           - complete
           - partial
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -45,8 +49,6 @@ jobs:
         with:
           yaml-file: tests/test.yaml
           version: ${{ matrix.esphome-version }}
-          platform: linux/amd64
-          cache: true
           release-summary: ${{ env.TEST_RELEASE_SUMMARY }}
           release-url: "https://github.com/esphome/build-action"
           complete-manifest: ${{ matrix.manifest == 'complete' }}

--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@ This action is used by the [ESPHome publish workflow](https://github.com/esphome
 
 ## Inputs
 
-| Name                | Default       | Description                                                                             |
-| ------------------- | ------------- | --------------------------------------------------------------------------------------- |
-| `yaml-file`         | _None_        | The YAML file to be compiled.                                                           |
-| `version`           | `latest`      | The ESPHome version to build using.                                                     |
-| `platform`          | `linux/amd64` | The docker platform to use during build. (linux/amd64, linux/arm64, linux/arm/v7)       |
-| `release-summary`   | _None_        | A small summary of the release that will be added to the manifest file.                 |
-| `release-url`       | _None_        | A URL to the release page that will be added to the manifest file.                      |
-| `complete-manifest` | `false`       | Whether to output a complete manifest file. Defaults to output a partial manifest only. |
+| Name                | Default  | Description                                                                             |
+| ------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `yaml-file`         | _None_   | The YAML file to be compiled.                                                           |
+| `version`           | `latest` | The ESPHome version to build using.                                                     |
+| `release-summary`   | _None_   | A small summary of the release that will be added to the manifest file.                 |
+| `release-url`       | _None_   | A URL to the release page that will be added to the manifest file.                      |
+| `complete-manifest` | `false`  | Whether to output a complete manifest file. Defaults to output a partial manifest only. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Platform (OS/Arch) to use
     required: false
     default: linux/amd64
+    deprecationMessage: |
+      The platform input is no longer used. ESPHome and this action supports
+      amd64 and arm64, both are supported by GitHub as the job runner architecture
+      by altering `runs-on` in the workflow.
   release-summary:
     description: Release summary
     required: false
@@ -46,12 +50,8 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3.6.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3.10.0
-      with:
-        platforms: ${{ inputs.platform }}
     - name: Build ESPHome image
       uses: docker/build-push-action@v6.15.0
       env:
@@ -62,7 +62,6 @@ runs:
         load: true
         tags: esphome:${{ inputs.version }}
         build-args: VERSION=${{ inputs.version }}
-        platforms: ${{ inputs.platform }}
     - name: Run container
       shell: bash
       id: build-step
@@ -73,7 +72,6 @@ runs:
         )
 
         docker run --rm \
-          --platform ${{ inputs.platform }} \
           --workdir /github/workspace \
           -v "$(pwd)":"/github/workspace" -v "$HOME:$HOME" \
           --user $(id -u):$(id -g) \

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
- removes the `cache` input from ci
- deprecates `platform` input and doesnt use it anymore.
- Internally test on the native amd64 and arm64 runners