### PR TITLE
Update shebang to be more portable

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
The newest esphome dev images moved the location of python3 :see_no_evil: 